### PR TITLE
Updated for MaybeUninit and hal::digital::v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ version = "0.2.0"
 
 [dependencies]
 embedded-hal = "0.2.0"
-generic-array = "0.11.0"
+generic-array = "0.13.2"


### PR DESCRIPTION
l3gd20 has a couple of issues compiling with recent Rust, because of changes in the hal, with the move to hal::digital::v2, and with men::uninitialised being deprecated. I've made changes to bring both up to date.

There are a couple of other minor text changes, but they're consequences of editing and need not be accepted.

This is my first Rust PR, so I hope it is helpful and that I'm taking the correct steps. If not, let me know how to follow this process.